### PR TITLE
Replace Netlify Forms with Resend API for contact form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@turf/distance": "^6.0.1",
         "ajv": "^8.17.1",
         "ajv-keywords": "^5.1.0",
+        "axios": "^1.16.1",
         "babel-plugin-styled-components": "^1.10.7",
         "dotenv": "^8.2.0",
         "embla-carousel-autoplay": "^8.3.0",
@@ -10014,19 +10015,20 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -16477,9 +16479,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -26541,9 +26543,12 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@turf/distance": "^6.0.1",
     "ajv": "^8.17.1",
     "ajv-keywords": "^5.1.0",
+    "axios": "^1.16.1",
     "babel-plugin-styled-components": "^1.10.7",
     "dotenv": "^8.2.0",
     "embla-carousel-autoplay": "^8.3.0",

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -1,0 +1,46 @@
+import axios from "axios"
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" })
+  }
+
+  const { name, phone, email, company, message } = req.body
+
+  if (!name || !phone || !email || !company) {
+    return res.status(400).json({ error: "Missing required fields" })
+  }
+
+  try {
+    await axios.post(
+      "https://api.resend.com/emails",
+      {
+        from: "Frey Farms Website <onboarding@resend.dev>",
+        to: "hilarylong@freyfarms.com",
+        reply_to: email,
+        subject: `Bubbler Program Inquiry from ${name}`,
+        html: [
+          `<h2>New Bubbler Program Inquiry</h2>`,
+          `<p><strong>Name:</strong> ${name}</p>`,
+          `<p><strong>Phone:</strong> ${phone}</p>`,
+          `<p><strong>Email:</strong> ${email}</p>`,
+          `<p><strong>Company:</strong> ${company}</p>`,
+          `<p><strong>Message:</strong></p>`,
+          `<p>${message || "No message provided."}</p>`,
+        ].join(""),
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+      }
+    )
+
+    return res.status(200).json({ success: true })
+  } catch (err) {
+    const status = err.response?.status || 500
+    const detail = err.response?.data?.message || "Failed to send email"
+    return res.status(status).json({ error: detail })
+  }
+}

--- a/src/pages/custom-bubbler-beverage-program.js
+++ b/src/pages/custom-bubbler-beverage-program.js
@@ -1,10 +1,9 @@
-import React from "react"
+import React, { useState } from "react"
 import styled from "styled-components";
-import { graphql } from 'gatsby'
+import { graphql } from ‘gatsby’
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import NetlifyForm from 'react-netlify-form'
 
 import Hero from "../components/hero"
 import Container from "../components/container"
@@ -14,7 +13,44 @@ import H3 from "../components/typography/h3"
 import P from "../components/typography/p"
 
 
-const IndexPage = ({ data }) => (
+const IndexPage = ({ data }) => {
+  const [status, setStatus] = useState("idle")
+  const [errorMsg, setErrorMsg] = useState("")
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setStatus("loading")
+    setErrorMsg("")
+
+    const form = e.target
+    const payload = {
+      name: form.Name.value,
+      phone: form.Phone.value,
+      email: form.Email.value,
+      company: form.Company.value,
+      message: form.message.value,
+    }
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || "Something went wrong. Please try again.")
+      }
+
+      setStatus("success")
+    } catch (err) {
+      setErrorMsg(err.message)
+      setStatus("error")
+    }
+  }
+
+  return (
   <Layout>
     <SEO
       title="Our Story | Frey Farms"
@@ -27,41 +63,40 @@ const IndexPage = ({ data }) => (
 
       <Container width="750px">
         <H2 textAlign="center">Let’s Create a Bubbler Lineup Together</H2>
-      <NetlifyForm
-        name='Custom Bubbler Program'
-        honeyPot="bot-field"
-      >
-        {({ loading, error, success }) => (
-          <div>
-            {loading &&
-              <div>Loading...</div>
-            }
-            {error &&
-              <div>Your information was not sent. Please try again later.</div>
-            }
-            {success &&
-              <H3 style={{ margin: "3em 0" }}>Someone from Our Team will Get in Touch with You Shortly!</H3>
-            }
-            {!loading && !success &&
-              <Flex>
-                <Input type='text' name='Name' placeholder="Your Name" required />
-                <Input type='tel' name='Phone' placeholder="Your phone number" required />
-                <Input type="text" name="Email" placeholder="Your email" required />
-                <Input type="text" name="Companyu" placeholder="Company name" required />
-                <Textarea name='message' rows="4" placeholder="Enter your message here..."></Textarea>
-                <Input type="hidden" name='bot-field' />
-                <Button type="submit">Request Information</Button>
-              </Flex>
-            }
-          </div>
+        {status === "success" ? (
+          <H3 style={{ margin: "3em 0" }}>Someone from Our Team will Get in Touch with You Shortly!</H3>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <Flex>
+              {status === "error" && <ErrorMessage>{errorMsg}</ErrorMessage>}
+              <Input type=’text’ name=’Name’ placeholder="Your Name" required />
+              <Input type=’tel’ name=’Phone’ placeholder="Your phone number" required />
+              <Input type="email" name="Email" placeholder="Your email" required />
+              <Input type="text" name="Company" placeholder="Company name" required />
+              <Textarea name=’message’ rows="4" placeholder="Enter your message here..."></Textarea>
+              <Button type="submit" disabled={status === "loading"}>
+                {status === "loading" ? "Sending..." : "Request Information"}
+              </Button>
+            </Flex>
+          </form>
         )}
-      </NetlifyForm>
       </Container>
     </Container>
 
   </Layout>
-)
+  )
+}
 
+
+const ErrorMessage = styled.div`
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+  padding: 0.75em 1em;
+  border-radius: 5px;
+  margin-bottom: 1em;
+  font-family: 'Brandon Grotesque Regular';
+`
 
 const Flex = styled.div`
   display: grid;
@@ -123,6 +158,10 @@ const Button = styled.button`
   &:hover {
     background: #292825;
     box-shadow: 0px 4px 7px rgba(33,32,30, .27);
+  }
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `
 


### PR DESCRIPTION
## Summary
- **Removed** `react-netlify-form` dependency from the Bubbler Beverage Program contact form
- **Added** Gatsby serverless function at `/api/contact` that sends form submissions via the [Resend HTTP API](https://resend.com/docs/api-reference/emails/send-email) using axios (no Resend SDK — avoids Node 20+ requirement)
- **Added** error state handling to the form UI: styled red error banner, loading/disabled button state, and proper `type="email"` validation
- **Fixed** typo in form field name (`Companyu` → `Company`)

## Details
- **From address:** `onboarding@resend.dev`
- **Recipient:** `hilarylong@freyfarms.com`
- **Reply-To:** set to the submitter's email address
- **Env var required:** `RESEND_API_KEY` — must be set in Netlify environment variables

## Test plan
- [ ] Set `RESEND_API_KEY` in Netlify env vars
- [ ] Submit the form and verify email arrives at hilarylong@freyfarms.com
- [ ] Verify reply-to is set to the submitter's email
- [ ] Test form validation (required fields, email format)
- [ ] Test error state by temporarily using an invalid API key
- [ ] Optionally remove `react-netlify-form` from package.json if no other pages use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)